### PR TITLE
确保终点可达

### DIFF
--- a/MazeGame/MazeGame.cpp
+++ b/MazeGame/MazeGame.cpp
@@ -133,6 +133,14 @@ void Maze::generate() {
 	// 确保起点和终点是通路
 	grid[start.second][start.first] = false;
 	grid[end.second][end.first] = false;
+	if (grid[end.second + 1][end.first] == true &&
+	grid[end.second - 1][end.first] == true &&
+	grid[end.second][end.first + 1] == true &&
+	grid[end.second][end.first - 1] == true)
+{
+	grid[end.second][end.first] = true;
+	generate();
+}
 }
 
 void Maze::generateStartAndEnd() {


### PR DESCRIPTION
这个修改应该比较安全，迷宫的位置因迷宫起点的奇偶性而摆动，如果终点随机生成的位置在迷宫之外，同时迷宫与终点相邻的一侧为墙，会出现无法到达终点的情况，现在如果有问题，我们就重新生成一个迷宫